### PR TITLE
Output <div>s instead of <p>s

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -890,7 +890,7 @@ Parser.prototype.tok = function() {
         : this.token.text;
     }
     case 'paragraph': {
-      return React.DOM.p(null, this.inline.output(this.token.text));
+      return React.DOM.div({className: 'paragraph'}, this.inline.output(this.token.text));
     }
     case 'text': {
       return React.DOM.p(null, this.parseText());


### PR DESCRIPTION
This lets us put `<div>`s (from widgets) inside of the question and hints, without react getting confused.
