### PR TITLE
add paragraphFn option to control the type of React.DOM component output

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -890,7 +890,9 @@ Parser.prototype.tok = function() {
         : this.token.text;
     }
     case 'paragraph': {
-      return React.DOM.div({className: 'paragraph'}, this.inline.output(this.token.text));
+      return this.options.paragraphFn
+        ? this.options.paragraphFn.call(this, this.inline.output(this.token.text))
+        : React.DOM.p(null, this.inline.output(this.token.text));
     }
     case 'text': {
       return React.DOM.p(null, this.parseText());
@@ -1046,7 +1048,8 @@ marked.defaults = {
   silent: false,
   highlight: null,
   langPrefix: 'lang-',
-  smartypants: false
+  smartypants: false,
+  paragraphFn: null
 };
 
 /**

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -891,7 +891,7 @@ Parser.prototype.tok = function() {
     }
     case 'paragraph': {
       return this.options.paragraphFn
-        ? this.options.paragraphFn.call(this, this.inline.output(this.token.text))
+        ? this.options.paragraphFn.call(null, this.inline.output(this.token.text))
         : React.DOM.p(null, this.inline.output(this.token.text));
     }
     case 'text': {


### PR DESCRIPTION
Love the work you've done here, but I'd like to get paragraph tags out of marked-react for paragraph blocks.

This adds an option to preserve the existing behavior:

``` js
marked.setOptions({
  paragraphFn: function(text) {
    return React.DOM.div({className: 'paragraph'}, text);
  }
});
```

Example use:

```
rcs at Boreas in ~/Devel/marked-react on master
❯ node
> global.React = require('react');1;
1
> marked = require('.');1;
1
> React.renderComponentToString(marked('__example text__')[0])
'<p data-reactid=".smjfreqzgg" data-react-checksum="-309317655"><strong data-reactid=".smjfreqzgg.0"><span data-reactid=".smjfreqzgg.0.0">example text</span></strong></p>'
> marked.setOptions({paragraphFn: function(text) { return React.DOM.div({className: 'paragraph'}, text); }});1;
1
> React.renderComponentToString(marked('__example text__')[0])
'<div class="paragraph" data-reactid=".iyr85qij9c" data-react-checksum="-295487969"><strong data-reactid=".iyr85qij9c.0"><span data-reactid=".iyr85qij9c.0.0">example text</span></strong></div>'
>
```
