### PR TITLE
Add URL sanitation to avoid javascript: links

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -680,7 +680,7 @@ InlineLexer.prototype.sanitizeUrl = function(url) {
   if (this.options.sanitize) {
     try {
       var prot = decodeURIComponent(url)
-          .replace(/[^\w:]/g, '')
+          .replace(/[^A-Za-z0-9:]/g, '')
           .toLowerCase();
       if (prot.indexOf('javascript:') === 0) {
         return '#';

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -575,7 +575,7 @@ InlineLexer.prototype.output = function(src) {
         text = cap[1];
         href = text;
       }
-      out.push(React.DOM.a({href: href}, text));
+      out.push(React.DOM.a({href: this.sanitizeUrl(href)}, text));
       continue;
     }
 
@@ -584,7 +584,7 @@ InlineLexer.prototype.output = function(src) {
       src = src.substring(cap[0].length);
       text = cap[1];
       href = text;
-      out.push(React.DOM.a({href: href}, text));
+      out.push(React.DOM.a({href: this.sanitizeUrl(href)}, text));
       continue;
     }
 
@@ -673,18 +673,38 @@ InlineLexer.prototype.output = function(src) {
 };
 
 /**
+ * Sanitize a URL for a link or image
+ */
+
+InlineLexer.prototype.sanitizeUrl = function(url) {
+  if (this.options.sanitize) {
+    try {
+      var prot = decodeURIComponent(url)
+          .replace(/[^\w:]/g, '')
+          .toLowerCase();
+      if (prot.indexOf('javascript:') === 0) {
+        return '#';
+      }
+    } catch (e) {
+      return '#';
+    }
+  }
+  return url;
+};
+
+/**
  * Compile Link
  */
 
 InlineLexer.prototype.outputLink = function(cap, link) {
   if (cap[0][0] !== '!') {
     return React.DOM.a({
-      href: link.href,
+      href: this.sanitizeUrl(link.href),
       title: link.title
     }, this.output(cap[1]));
   } else {
     return React.DOM.img({
-      src: link.href,
+      src: this.sanitizeUrl(link.href),
       alt: cap[1],
       title: link.title
     }, null);


### PR DESCRIPTION
Summary:
Original code taken from
https://github.com/chjj/marked/commit/904c71b7713979b01d5bc5264c2808c73fef99a7

Test plan:
Added this to https://github.com/Khan/perseus and made an image, a link,
an autolink, and a url (technically, the regex recongizing this already
seems to ignore javascript: links, but sanitizing everything seems to
make more sense than doing it only when obviously necessary), all
starting with javascript:, and made sure that none of them executed the
javascript.
