### PR TITLE
Use paragraphFn instead of <p> for 'text'

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -915,7 +915,9 @@ Parser.prototype.tok = function() {
         : React.DOM.p(null, this.inline.output(this.token.text));
     }
     case 'text': {
-      return React.DOM.p(null, this.parseText());
+      return this.options.paragraphFn
+        ? this.options.paragraphFn.call(null, this.parseText())
+        : React.DOM.p(null, this.parseText());
     }
   }
 };


### PR DESCRIPTION
Summary:
For markedown blocks that aren't followed by a header/blockquote/etc,
they are rendered as 'text' instead of 'paragraph', which was rendering
a <p> tag even when a special paragraphFn renderer was specified. This
fixes that, so that clients can avoid rendering any <p> tags (which is
especially important because you cannot put <div>s in <p> tags, and
attempting to do so confuses the browser and react.

Test Plan:
Cross fingers
