### PR TITLE
Make anchor configurable

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -575,7 +575,7 @@ InlineLexer.prototype.output = function(src) {
         text = cap[1];
         href = text;
       }
-      out.push(React.DOM.a({href: this.sanitizeUrl(href)}, text));
+      out.push(this.options.anchorFn.call(null, {href: this.sanitizeUrl(href)}, text));
       continue;
     }
 
@@ -584,7 +584,7 @@ InlineLexer.prototype.output = function(src) {
       src = src.substring(cap[0].length);
       text = cap[1];
       href = text;
-      out.push(React.DOM.a({href: this.sanitizeUrl(href)}, text));
+      out.push(this.options.anchorFn.call(null, {href: this.sanitizeUrl(href)}, text));
       continue;
     }
 
@@ -698,7 +698,7 @@ InlineLexer.prototype.sanitizeUrl = function(url) {
 
 InlineLexer.prototype.outputLink = function(cap, link) {
   if (cap[0][0] !== '!') {
-    return React.DOM.a({
+    return this.options.anchorFn.call(null, {
       href: this.sanitizeUrl(link.href),
       title: link.title
     }, this.output(cap[1]));
@@ -1071,7 +1071,8 @@ marked.defaults = {
   highlight: null,
   langPrefix: 'lang-',
   smartypants: false,
-  paragraphFn: null
+  paragraphFn: null,
+  anchorFn: React.DOM.a
 };
 
 /**

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -4,6 +4,8 @@
  * https://github.com/chjj/marked
  */
 
+var React = require('react');
+
 ;(function() {
 
 /**

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -703,7 +703,7 @@ InlineLexer.prototype.outputLink = function(cap, link) {
       title: link.title
     }, this.output(cap[1]));
   } else {
-    return React.DOM.img({
+    return this.options.imageFn.call(null, {
       src: this.sanitizeUrl(link.href),
       alt: cap[1],
       title: link.title
@@ -1072,7 +1072,8 @@ marked.defaults = {
   langPrefix: 'lang-',
   smartypants: false,
   paragraphFn: null,
-  anchorFn: React.DOM.a
+  anchorFn: React.DOM.a,
+  imageFn: React.DOM.img
 };
 
 /**


### PR DESCRIPTION
This patch makes `<a>` tags configurable. In my case, I want to use react-router `Link` components for internal site links.
