### PR TITLE
Tables: output <tbody> for bodies

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -861,7 +861,7 @@ Parser.prototype.tok = function() {
         }
         body.push(React.DOM.tr(null, row));
       }
-      table.push(React.DOM.thead(null, body));
+      table.push(React.DOM.tbody(null, body));
 
       return React.DOM.table(null, table);
     }


### PR DESCRIPTION
Summary:
Tables should have a thead and a tbody, instead of
two theads

Test Plan:
 #yolo

Auditors: alpert
